### PR TITLE
大修改MainPage，修改Account，修改两个ViewModel

### DIFF
--- a/ShowMeMyMoney/Account.xaml
+++ b/ShowMeMyMoney/Account.xaml
@@ -1,0 +1,64 @@
+﻿<Page
+    x:Class="ShowMeMyMoney.Account"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:ShowMeMyMoney"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+    <Page.Resources>
+        <Style TargetType="Button">
+            <Setter  Property="FontWeight" Value="ExtraBold"/>
+            <Setter Property="Width" Value="60" />
+            <Setter Property="HorizontalAlignment" Value="Center" />
+            <Setter Property="Foreground" Value="White" />
+        </Style>
+        <Style TargetType="Rectangle">
+            <Setter Property="RadiusX" Value="20" />
+            <Setter Property="RadiusY" Value="20" />
+            <Setter Property="Width" Value="60" />
+        </Style>
+        <CollectionViewSource x:Name="ExpenseCGList" Source="{x:Bind CategoryViewModel.AllExpenseCatagoryItems}" />
+        <CollectionViewSource x:Name="IncomeCGList"  Source="{x:Bind CategoryViewModel.AllIncomeCatagoryItems}" />
+    </Page.Resources>
+
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="60" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <TextBlock TextAlignment="Center" VerticalAlignment="Center" Text="添加新账单"  FontSize="28"  Grid.Row="0" />
+        <ScrollViewer Grid.Row="1" Margin="0,0,0,0">
+            <StackPanel Margin="20,0,0,0">
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0, 20, 0, 0 ">
+                    <RadioButton Content="支出" x:Name="expense"  Checked="out_Checked"   />
+                    <RadioButton Content="收入" Tag="in" x:Name="income" Checked="income_Checked"/>
+                </StackPanel>
+                <ComboBox Width="300" ItemsSource="{Binding Source={StaticResource ExpenseCGList}, Mode=OneWay}" DisplayMemberPath="name" Header="开支分类"  HorizontalAlignment="Center" x:Name="ExpenseCategory" Margin="0, 20, 0, 0">
+                </ComboBox>
+                <ComboBox Width="300" ItemsSource="{Binding Source={StaticResource IncomeCGList}, Mode=OneWay}" DisplayMemberPath="name" Header="收入分类"  HorizontalAlignment="Center" x:Name="IncomeCategory" Margin="0, 20, 0, 0">
+                </ComboBox>
+                <Grid Margin="0,5,0,0">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="1*" />
+                    </Grid.ColumnDefinitions>
+                    <TextBox Grid.Column="0"  x:Name="Amount" Header="金额" Width="150" HorizontalAlignment="Center" Margin="20,0,0,0" />
+                    <CheckBox x:Name="PocketMoney" Margin="15, 0, 0, 0" VerticalAlignment="Bottom" Content="私房钱" Grid.Column="1" HorizontalAlignment="Center"/>
+                </Grid>
+                <TextBox  x:Name="Description" Width="300" Height="96" Margin="0,20,0,0" Header="详情" />
+                <DatePicker x:Name="Date" Width="300" Margin="0,20,0,0" Header="日期" HorizontalAlignment="Center" />
+                <Grid Width="300" Margin="0,24,0,0">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Rectangle Grid.Column="0" Fill="LightCoral"  />
+                    <Button  Grid.Column="0" x:Name="createButton" Content="√"  Background="{x:Null}" Click="createButton_Click"/>
+                    <Rectangle Grid.Column="1" Fill="LightBlue" />
+                    <Button Grid.Column="1" x:Name="canclButton" Content="×"  Background="{x:Null}" Click="canclButton_Click"/>
+                </Grid>
+            </StackPanel>
+        </ScrollViewer>
+    </Grid>
+</Page>

--- a/ShowMeMyMoney/MainPage.xaml
+++ b/ShowMeMyMoney/MainPage.xaml
@@ -27,70 +27,141 @@
                       
                        Style="{StaticResource myTitle}"
                       ></TextBlock>
-            <StackPanel x:Name="shareBar" Orientation="Horizontal" Margin="10">
+            <!-- 本月总预算 -->
+                <Border BorderBrush="ForestGreen" BorderThickness="1" Margin="15"  
+                                    HorizontalAlignment="Center"
+                                  VerticalAlignment="Top"     Width="Auto" >
+                <Grid x:Name="TotalBudgetItem" Width="400" Margin="10">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="1*"/>
+                        <ColumnDefinition Width="1*" />
+                        <ColumnDefinition Width="2*" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Text="本月预算" Foreground="ForestGreen"  Padding="5" FontSize="20"
+                      Grid.Column="0"   VerticalAlignment="Center" />
+                    <TextBlock FontSize="20" VerticalAlignment="Center"
+                           Text="1500" Foreground="ForestGreen" Grid.Column="1" />
+                    <TextBlock x:Name="TotalBudgetProportion" FontSize="20" VerticalAlignment="Center"
+                           Text="已使用50%" Foreground="ForestGreen" Grid.Column="2" />
+                </Grid>
+            </Border>
+            
+            <!-- 开支展示区 -->
+            <Border BorderBrush="DodgerBlue" BorderThickness="1" Margin="15"  
+                                    HorizontalAlignment="Center"
+                                  VerticalAlignment="Top"     Width="Auto" >
+                <Grid x:Name="TotalExpenseItem" Width="400" Margin="5">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="1*"/>
+                    <ColumnDefinition Width="1*" /> 
+                </Grid.ColumnDefinitions>
+                    <TextBlock Text="总开支" Foreground="DodgerBlue"  Padding="5" FontSize="20"
+                      Grid.Column="0"   VerticalAlignment="Center" />  
+                <TextBlock x:Name="TotalExpenseAmount"  FontSize="20" VerticalAlignment="Center"
+                           Text="{x:Bind totalExpense}" Foreground="DodgerBlue" Grid.Column="1" /> 
+                 </Grid>
+            </Border>
+
+            <!-- 私房钱 -->
+
+            <Border BorderBrush="Orange" BorderThickness="1" Margin="15"  
+                                    HorizontalAlignment="Center"
+                                  VerticalAlignment="Top"     Width="Auto" >
+                <Grid x:Name="PocketMoneyItem" Width="400" Margin="3">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="1*"/>
+                        <ColumnDefinition Width="1*" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Text="私房钱" Foreground="Orange"  Padding="5" FontSize="20"
+                      Grid.Column="0"   VerticalAlignment="Center" />
+
+                    <TextBlock x:Name="PocketMoneyAmount" FontSize="20" VerticalAlignment="Center"
+                           Text="还剩800RMB" Foreground="Orange" Grid.Column="1" />
+                </Grid>
+            </Border>
+
+
+            <!-- 比例颜色条 -->
+                <StackPanel x:Name="shareBar" Orientation="Horizontal" Margin="10" Height="32" >
                 <TextBlock/>
-
             </StackPanel>
-            <!--
-            <ListView  IsItemClickEnabled="False" 
-                         ItemsSource="{x:Bind categoryTable, Mode=OneWay}">
-                <ListView.ItemContainerStyle>
-                    <Style TargetType="ListViewItem">
-                        <Setter Property="VerticalAlignment" Value="Center"/>
-                        <Setter Property="HorizontalAlignment" Value="Stretch"/>
-                        <Setter Property="Width" Value="Auto"/>
-                    </Style>
-                </ListView.ItemContainerStyle>
-                <ListView.ItemsPanel>
-                    <ItemsPanelTemplate>
-                        <VirtualizingStackPanel Orientation="Horizontal"
-                VerticalAlignment="Top"
-                ScrollViewer.HorizontalScrollMode="Enabled"
-                ScrollViewer.VerticalScrollMode="Disabled"/>
-                    </ItemsPanelTemplate>
-                </ListView.ItemsPanel>
-                <ListView.ItemTemplate >
-                    <DataTemplate x:DataType="md:categoryItem" >
-                        <Grid>
-                            <Rectangle Fill="{x:Bind color}" Width="{x:Bind share}" Height="30"/>
-                        </Grid>
-                            </DataTemplate>
-                </ListView.ItemTemplate>
-            </ListView>
-            -->
 
-
-            <ListView ItemClick="ShowCategory_Click" IsItemClickEnabled="True"
-                         ItemsSource="{x:Bind categoryTable, Mode=OneWay}">
+            <Border x:Name="表头" BorderBrush="Black" BorderThickness="1" 
+                                    HorizontalAlignment="Center"
+                                  VerticalAlignment="Center"     Width="Auto" >
+                <Grid   Width="400" >
+                <Grid.ColumnDefinitions >
+                    <ColumnDefinition Width="1*"/>
+                    <ColumnDefinition Width="1*" />
+                    <ColumnDefinition Width="1*" />
+                </Grid.ColumnDefinitions>
+                    <TextBlock Text="分类名" Foreground="Black"  Padding="5"
+                              Grid.Column="0"   HorizontalAlignment="Center"      VerticalAlignment="Center"/>
+                    <TextBlock  Text="比例" Foreground="Black" Grid.Column="1" HorizontalAlignment="Center"  VerticalAlignment="Center"/>
+                    <TextBlock  Text="总额" Foreground="Black" Grid.Column="2" HorizontalAlignment="Center"  VerticalAlignment="Center"/>
+      
+            </Grid>
+            </Border>
+            <ListView ItemClick="ShowCategory_Click" IsItemClickEnabled="True" HorizontalAlignment="Center"
+                x:Name="expenseList"         ItemsSource="{x:Bind categoryViewModel.AllExpenseCatagoryItems, Mode=OneWay}">
                 <ListView.ItemTemplate>
                     <DataTemplate x:DataType="md:categoryItem">
-                        <Grid Width="400">
+                        <Border Background="{x:Bind color}" BorderThickness="1"  
+                                    HorizontalAlignment="Center"
+                                  VerticalAlignment="Center"      Width="Auto" Grid.Column="0">
+                            <Grid Width="400">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="1*"/>
                                 <ColumnDefinition Width="1*" />
                                 <ColumnDefinition Width="1*" />
-                            </Grid.ColumnDefinitions>
-                            <Border BorderBrush="{x:Bind color}" BorderThickness="1" 
-                                    HorizontalAlignment="Center"
-                                  VerticalAlignment="Top"     Width="Auto" Grid.Column="0">
-                                <TextBlock Text="{x:Bind name}" Foreground="{x:Bind color}"
-                                           Padding="5"
+                            </Grid.ColumnDefinitions> 
+                            <TextBlock Text="{x:Bind name}" Foreground="White"
+                                           Padding="5" HorizontalAlignment="Center"  FontWeight="ExtraBold"
                                        VerticalAlignment="Center"/>
-
-                            </Border>
-                            <TextBlock  Text="{x:Bind share}" Foreground="{x:Bind color}" Grid.Column="1" />
-                            <TextBlock  Text="{x:Bind share}" Foreground="{x:Bind color}"  Grid.Column="2" />
-
-                        </Grid>
-
-
+                                <TextBlock  Text="{x:Bind share}"  Foreground="White" Grid.Column="1"  HorizontalAlignment="Center"  VerticalAlignment="Center" />
+                                <TextBlock  Text="{x:Bind amount}"  Foreground="White" Grid.Column="2" HorizontalAlignment="Center"  VerticalAlignment="Center" />
+                            </Grid>  
+                        </Border>
                     </DataTemplate>
                 </ListView.ItemTemplate>
             </ListView>
-
-
-            <StackPanel Orientation="Horizontal">
-
+            <!-- 收入展示区 -->
+            <Border BorderBrush="Pink" BorderThickness="1" Margin="15,0,15,15"  
+                                    HorizontalAlignment="Center"
+                                  VerticalAlignment="Top"     Width="Auto" >
+                <Grid x:Name="TotalIncomeItem" Width="400" Margin="5">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="1*"/>
+                        <ColumnDefinition Width="1*" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Text="总收入" Foreground="Pink"  Padding="5" FontSize="20"
+                      Grid.Column="0"   VerticalAlignment="Center" />
+                    <TextBlock x:Name="TotalIncomeAmount"  FontSize="20" VerticalAlignment="Center"
+                           Text="0.0" Foreground="Pink" Grid.Column="1" />
+                </Grid>
+            </Border>
+            <ListView ItemClick="ShowCategory_Click" IsItemClickEnabled="True" HorizontalAlignment="Center"
+                x:Name="incomeList"         ItemsSource="{x:Bind categoryViewModel.AllIncomeCatagoryItems, Mode=OneWay}">
+                <ListView.ItemTemplate>
+                    <DataTemplate x:DataType="md:categoryItem">
+                        <Border Background="{x:Bind color}" BorderThickness="1"  
+                                    HorizontalAlignment="Center"
+                                  VerticalAlignment="Center"      Width="Auto" Grid.Column="0">
+                            <Grid Width="400">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="1*"/>
+                                    <ColumnDefinition Width="1*" /> 
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Text="{x:Bind name}" Foreground="White"
+                                           Padding="5" HorizontalAlignment="Center"  FontWeight="ExtraBold"
+                                       VerticalAlignment="Center"/>
+                                <TextBlock  Text="{x:Bind amount}"  Foreground="White" Grid.Column="1"  HorizontalAlignment="Center"  VerticalAlignment="Center" />
+                             </Grid>
+                        </Border>
+                    </DataTemplate>
+                </ListView.ItemTemplate>
+            </ListView>
+            <StackPanel Orientation="Horizontal"> 
                 <AppBarButton x:Name="AddNewCategoryButton" Label="添加新分类"
                           Click="AddNewCategoryButton_Click"
                      Icon="Add" Width="117"></AppBarButton>
@@ -111,11 +182,15 @@
                      PrimaryButtonClick="AddNewCategoryDialog_PrimaryButtonClick"
                        SecondaryButtonClick="AddNewCategoryDialog_SecondaryButtonClick" Margin="0,421,40,-88">
             <StackPanel Margin="10">
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" >
+                    <RadioButton Content="支出" x:Name="expenseButton" Checked="out_Checked"/>
+                    <RadioButton Content="收入" Tag="in" x:Name="incomeButton" Checked="in_Checked"/>
+                </StackPanel>
                 <TextBox x:Name="categoryName" Header="# 分类名称" />
-
+                
                 <Slider x:Name="shareSlider" Header="# 所占预算比例（百分比数值，1-100）"
                  ValueChanged="shareSlider_ValueChanged"
-                        Margin="0,0,35,0"/> 
+                        Margin="0,0,35,0"/>
                 <ComboBox x:Name="ColorPallete_Combo"  Header="# 分类颜色"
                   ItemsSource="{Binding Colors}" SelectedItem="{Binding SelectedColorName, Mode=TwoWay}" SelectionChanged="ColorPalleteCombo_SelectionChanged">
                     <ComboBox.ItemTemplate>
@@ -132,7 +207,7 @@
                     </ComboBox.ItemTemplate>
                 </ComboBox>
                 <TextBox x:Name="categoryColor"  Visibility="Collapsed" />
-
+                
 
             </StackPanel>
         </ContentDialog>

--- a/ShowMeMyMoney/MainPage.xaml.cs
+++ b/ShowMeMyMoney/MainPage.xaml.cs
@@ -96,6 +96,7 @@ namespace ShowMeMyMoney
                     if (text == "" || text == "[]") return;
                     /* 将json文件中的东西反序列化，加入到metadata   */
                     Dictionary<string, double> p = JsonConvert.DeserializeObject<Dictionary<string, double>>(text);
+                    metadata = p;
                 } 
                
             }

--- a/ShowMeMyMoney/Model/accountItem.cs
+++ b/ShowMeMyMoney/Model/accountItem.cs
@@ -25,7 +25,22 @@ namespace ShowMeMyMoney.Model
         
 
         /* 主码 */
+        public accountItem(int category, DateTimeOffset date, double amount,
+                            bool isPocketMoney, bool inOrOut, string description)
+        {
+            _category = category;
+            _createDate = date;
+            _amount = amount;
+            _isPocketMoney = isPocketMoney;
+            _inOrOut = inOrOut;
+            _description = description;
+            _id =  Guid.NewGuid().ToString();
+        }
 
+        public accountItem()
+        {
+
+        }
         public event PropertyChangedEventHandler PropertyChanged;
 
         protected void RaisePropertyChanged(string name)

--- a/ShowMeMyMoney/Model/categoryItem.cs
+++ b/ShowMeMyMoney/Model/categoryItem.cs
@@ -9,23 +9,31 @@ namespace ShowMeMyMoney.Model
 {
      public class categoryItem
     {
-        public string name;
-        public int number;
+        public string name { get; set; }
+        public int number { get; }
         public string color;
         public double share;/* 分类当前所占百分比 */
+        public double amount; /* 分类当前总额 */ 
+        public bool inOrOut;
+        /* 0 表示支出，1表示收入*/
+
+
         [JsonConstructor]
-        public categoryItem(int i, string s,  double _share, string c)
+        public categoryItem(int i, string s,  double _share, string c, bool ioo)
         {
             name = s;
-            number = i;
+            number = Guid.NewGuid().GetHashCode()*(i+1);
             color = c;
             share = _share;
+            amount = 0;
+            inOrOut = ioo;
         }
         public categoryItem(string s, int i, string c)
         {
             name = s;
-            number = i;
-            color = c; 
+            number = Guid.NewGuid().GetHashCode();
+            color = c;
+            amount = 0;
         }
     }
 }

--- a/ShowMeMyMoney/Services/DBManager.cs
+++ b/ShowMeMyMoney/Services/DBManager.cs
@@ -37,9 +37,10 @@ namespace ShowMeMyMoney.Services
             }
         }
 
-        public void InsertIntoDatabase(Model.accountItem item) { 
+        public void InsertIntoDatabase(Model.accountItem item)
+        {
             var db = App.conn;
-            string SQLstmt = @"INSERT INTO accounts (Id, amount, createDate, " 
+            string SQLstmt = @"INSERT INTO accounts (Id, amount, createDate, "
                 + "category, isPocketMoney,inOrOut,"
                 + "description) VALUES (?, ?, ?, ?, ?, ?, ?)";
             try
@@ -53,7 +54,7 @@ namespace ShowMeMyMoney.Services
                     todostmt.Bind(5, item.isPocketMoney);
                     todostmt.Bind(6, item.inOrOut);
                     todostmt.Bind(7, item.description);
-                    var a = todostmt.Step(); 
+                    var a = todostmt.Step();
                 }
             }
             catch (Exception ex)
@@ -85,7 +86,7 @@ namespace ShowMeMyMoney.Services
 
 
                     int k = 0;
-                    i.id = (string)statement[k++];
+                    // i.id = (string)statement[k++];
                     i.amount = (double)statement[k++];
                     i.createDate = DateTimeOffset.Parse((string)statement[k++]);
                     i.category = (int)statement[k++];

--- a/ShowMeMyMoney/ViewModel/ViewModel.cs
+++ b/ShowMeMyMoney/ViewModel/ViewModel.cs
@@ -6,6 +6,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Windows.UI;
 
 namespace ShowMeMyMoney.ViewModel
 {
@@ -16,21 +17,30 @@ namespace ShowMeMyMoney.ViewModel
 
         private accountItem selectedItem = default(accountItem);
         public accountItem SelectedItem { get { return selectedItem; } set { this.selectedItem = value; } }
-
-
         public DBManager dbManager;
         public ViewModel()
         {
-            dbManager = new DBManager(); 
+            dbManager = new DBManager();
+           // AllCatagoryItem.Add(new categoryItem("play", 1, "red"));
+      //      public categoryItem(int i, string s, double _share, string c)
         }
         public async void getItemsFromDB(categoryItem ci)
         {
             /*  初始载入时连接到数据库，加载数据 */
         }
 
-        public async void AddAccountItem(accountItem item) {
-            /*  添加item并插入到数据库  */
+        /* public async void AddAccountItem(accountItem item) {
+             /*  添加item并插入到数据库  */
+
+        //}
+        public async void AddAccountItem(int categoryNum, DateTimeOffset date, double amount, 
+                            bool isPocketMoney, bool inOrOut, string description)
+        {
+            accountItem accountItem = new accountItem(categoryNum, date, amount, isPocketMoney, inOrOut, description);
+            allItems.Add(accountItem);
+            dbManager.InsertIntoDatabase(accountItem);
         }
+
         public async void RemoveAccountItem(string id)
         {
 

--- a/ShowMeMyMoney/ViewModel/categoryViewModel.cs
+++ b/ShowMeMyMoney/ViewModel/categoryViewModel.cs
@@ -1,0 +1,163 @@
+﻿using Newtonsoft.Json;
+using ShowMeMyMoney.Model;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ShowMeMyMoney.ViewModel
+{
+    class categoryViewModel
+    {
+        public ObservableCollection<categoryItem> AllCatagoryItems { get { return this.allCatagoryItems; } set { this.allCatagoryItems = value; } }
+        public ObservableCollection<categoryItem> allCatagoryItems = new ObservableCollection<categoryItem>();
+
+        /* 开支表 */
+        public ObservableCollection<categoryItem> AllExpenseCatagoryItems { get { return this.allExpenseCatagoryItems; } set { this.allExpenseCatagoryItems = value; } }
+        public ObservableCollection<categoryItem> allExpenseCatagoryItems = new ObservableCollection<categoryItem>();
+
+        /* 收入表 */
+        public ObservableCollection<categoryItem> AllIncomeCatagoryItems { get { return this.allIncomeCatagoryItems; } set { this.allIncomeCatagoryItems = value; } }
+        public ObservableCollection<categoryItem> allIncomeCatagoryItems = new ObservableCollection<categoryItem>();
+
+        static bool  EXPENSE = false, INCOME = true;
+
+        public double pocketMoneyAmount;
+
+        public categoryViewModel()
+        {
+            /* 读入本地json文件 */
+            initializeCategoryTable();
+            /* todo : 从本地读入私房钱数额 */
+            pocketMoneyAmount = 800;
+        }
+
+        private void initializeCategoryTable()
+        {
+            readFromTable("ExpenseCategoryTable");
+            readFromTable("IncomeCategoryTable");
+        }
+
+        public void AddCategoryItem(int index, string name, double _share, string color, bool b)
+        {
+            categoryItem categoryItem = new categoryItem(index, name, _share, color, b); 
+            AddCategoryItem(categoryItem);
+        }
+        public void AddCategoryItem(categoryItem newCategory)
+        {
+            if (newCategory.inOrOut == EXPENSE)
+            {
+                allExpenseCatagoryItems.Add(newCategory);
+            } else
+            {
+                allIncomeCatagoryItems.Add(newCategory);
+            }
+        }
+
+        public int getCategoryNum(string categoryName, bool expOrInc)
+        {
+            var items = expOrInc ? allIncomeCatagoryItems : allExpenseCatagoryItems;
+            foreach (var item in items)
+            {
+                if (item.name.Equals(categoryName))
+                    /* 要用.Equals判断才是判断内容  */
+                {
+                    return item.number;
+                }
+            }
+            return -1;
+        }
+        private async void readFromTable(string nameOfTable)
+        {
+            try
+            {
+                /*  读取json文件  */
+                var Folder = Windows.Storage.ApplicationData.Current.LocalFolder;
+                var item = await Folder.TryGetItemAsync(nameOfTable + ".json");
+                if (item == null)
+                {
+                    /* 第一次打开应用, 则无需进行后续操作 */
+                    /* 手动添加一个代表总开支的item */
+                   // allCatagoryItems.Add(new categoryItem(-1, "Total", 100, "Black"));
+                    return;
+                }
+                var file = await Folder.GetFileAsync(nameOfTable + ".json");
+
+                var data = await file.OpenReadAsync();
+
+                using (StreamReader r = new StreamReader(data.AsStream()))
+                {
+                    string text = r.ReadToEnd();
+
+                    /* 如果json是空的，也不能进行后续操作*/
+                    if (text == "" || text == "[]") return;
+                    /* 将json文件中的东西反序列化，加入到catagoryItem的数组   */
+                    categoryItem[] p = JsonConvert.DeserializeObject<categoryItem[]>(text);
+                    if (nameOfTable == EXPENSE_TABLE)
+                    {
+                        foreach (var i in p)
+                            allExpenseCatagoryItems.Add(i);
+                    }
+                    else if (nameOfTable == INCOME_TABLE)
+                    {
+                        foreach (var i in p)
+                            allIncomeCatagoryItems.Add(i);
+                    }
+                   
+                }
+                /* TODO:  去掉Total                */
+               
+            }
+            catch (Exception e)
+            {
+                throw e;
+            }
+        }
+
+        internal void UpdateCategoryByAccount(accountItem account)
+        {
+            bool expenseOrIncome = account.inOrOut;
+            var items = expenseOrIncome ?  allIncomeCatagoryItems : allExpenseCatagoryItems;
+            /* 如果是私房钱，不增加开支，只增加收入 */
+            if (account.isPocketMoney == true && expenseOrIncome == EXPENSE) return;
+            foreach (var i in items)
+            {
+                 if (account.category == i.number)
+                {
+                    i.amount += account.amount;
+                    saveCategoryTable(expenseOrIncome);
+                    return;
+                }
+            }
+
+        }
+
+        static string EXPENSE_TABLE = "ExpenseCategoryTable";
+        static string INCOME_TABLE = "IncomeCategoryTable";
+        public async void saveCategoryTable(Boolean incomeOrExpense)
+        {
+            string nameOfTable = incomeOrExpense? INCOME_TABLE: EXPENSE_TABLE;
+            ObservableCollection<categoryItem> table = incomeOrExpense ? allIncomeCatagoryItems : allExpenseCatagoryItems;
+            try
+            {
+                var Folder = Windows.Storage.ApplicationData.Current.LocalFolder;
+                var file = await Folder.CreateFileAsync(nameOfTable + ".json", Windows.Storage.CreationCollisionOption.ReplaceExisting);
+                var data = await file.OpenStreamForWriteAsync();
+
+                using (StreamWriter r = new StreamWriter(data))
+                {
+                      
+                    var serelizedfile = JsonConvert.SerializeObject(table);
+                    r.Write(serelizedfile);
+                }
+            }
+            catch (Exception e)
+            {
+                throw e;
+            }
+        }
+    }
+}


### PR DESCRIPTION
### MainPage更新
- 维护元数据：包括本月预算，总收入，总开支 
	- 初始化：从文件中读入
	- 总收入/总开支更新：Account跳转回MainPage时更新
	- 设置本月预算，从设置之日开始的一个月内无法再修改（未完成）
- 增加名为metadata的Dictionary，包括：本月预算，本月总收入，本月总支出，私房钱
- 视图修改
	- 收入和支出分别按分类展示
	- 新增新分类的对话框增加选项“收入/支出”
- 分类信息的json保存修改
	- 分两个json保存
- 修改一大堆相关函数

## 大修改：增加categoryItem收入/支出的属性
### categoryItem大修改
- 增加amount，表示分类总额，会在Account页面返回到MainPage时更新
- 增加inOrOut,表示分类是收入还是更新
- 修改number的生成方式
### categoryViewModel大修改
- 划分为allIncomeCategoryItems, allExpenseCategoryItems，原来的`allCategoryItems`废弃
- 增加 pocketMoneyAmount

### 修改MainPage和Account的通信
- Account收到的ViewModel将会有两个表，用户通过选择收入还是指出切换视图

## 私房钱逻辑
- 增加开支记录时减少私房钱，但不计入开支分类categoryItem的总额（体现在categoryViewModel中的UpdateCategoryByAccount）
- 私房钱的支出不影响总支出；
- 私房钱不会因时间推移而变动（不同于开支，收入，预算等需要月度更新）